### PR TITLE
Use local encryption setting as default

### DIFF
--- a/TPConnectionsManager.m
+++ b/TPConnectionsManager.m
@@ -274,8 +274,9 @@ static TPConnectionsManager * _connectionsManager = nil;
 	NSString * remoteAddress = [tcpSocket remoteAddress];
 	TPRemoteHost * remoteHost = [[TPHostsManager defaultManager] hostWithAddress:remoteAddress];
 	if(remoteHost == nil) {
-		NSLog(@"could not determine which host has IP %@, will use encrypted connection by default", remoteAddress);
-		return YES; // encrypted by default
+		BOOL encryptionActive = [[TPPreferencesManager sharedPreferencesManager] boolForPref:ENABLED_ENCRYPTION];
+		NSLog(@"could not determine which host has IP %@, will%s use encryption as it is configured so locally", remoteAddress, encryptionActive ? "" : " NOT");
+		return encryptionActive; // encrypted by default, if encryption is enabled locally
 	}
 	else {
 		return [[TPLocalHost localHost] pairWithHost:remoteHost hasCapability:TPHostEncryptionCapability];


### PR DESCRIPTION
If the client is not shared (advertised via Bonjour) the server does not find the encryption setting of the client and assumes always true.
This change will adjust this behaviour and defaults to the local setting on the server.